### PR TITLE
Use mt_rand() instead of rand() for better randomness.

### DIFF
--- a/src/Underscore/Underscore.php
+++ b/src/Underscore/Underscore.php
@@ -2470,7 +2470,7 @@ class Underscore
         if ($max === null)
             list($min, $max) = [0, $min];
 
-        return rand($min, $max);
+        return mt_rand($min, $max);
     }
 
     /**


### PR DESCRIPTION
Php's rand() is not random at all, mt_rand() uses Mersenne Twister pseudo random number generator:
http://cod.ifies.com/2008/05/php-rand01-on-windows-openssl-rand-on.html
